### PR TITLE
[feat]: create repo templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+## CI / workflows
+/.github/ @vpchung
+
+## Documentation
+/docs/ @vpchung @aclayton555 @aditigopalan @Bankso
+
+## Data models and standard terms
+/modules/ @aditigopalan @Bankso
+/templates/ @aditigopalan @Bankso

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Report an issue with an existing standard term
+title: '[bug] '
+labels: bug
+assignees: aditigopalan
+
+---
+
+## Describe the issue with the metadata/term
+<!-- 
+A clear and concise description of what the issue is.  Changing terminology may
+result in breaking changes downstream, so this change must be well-justified.
+-->
+
+
+## Possible alternatives
+<!-- 
+Please include your sources, if possible.
+-->
+
+
+## Additional comments
+

--- a/.github/RELEASE.yml
+++ b/.github/RELEASE.yml
@@ -1,0 +1,18 @@
+changelog:
+  exclude:
+    authors:
+      - mc2center-bot
+  categories:
+    - title: New changes
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - bug
+          - misc
+    - title: Bug fixes
+      labels:
+        - bug
+    - title: Compatible with DCA/schematic versions
+      labels:
+        - misc

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+Fixes #(GH issue number)
+
+## Changelog
+<!-- Itemize the changes made in this PR, for example: -->
+ - Added ...
+ - Removed ...
+ 


### PR DESCRIPTION
Fixes #47 

## Changelog
- Add templates for:
   - Pull request, including which ticket the PR will address
   - Bug report, which will auto-assign Aditi as the assignee
   - Release notes, which will include a section on which schematic/DCA versions the latest release is compatible with
- Add a codeowners file, so that PRs will auto-assign code reviewers, based on ownerships:
   - anything in .github: Verena
   - documentations: Ashley, Aditi, Orion, Verena
   - data model: Aditi, Orion
 