### PR TITLE
add workflow for drafting release

### DIFF
--- a/.github/release-template.yml
+++ b/.github/release-template.yml
@@ -1,0 +1,24 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+change-template: '- $TITLE (#$NUMBER)'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+exclude-labels:
+  - 'non-release'
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  ## Contributors
+
+  $CONTRIBUTORS

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,42 @@
+name: Create a new data model release
+
+on:
+  issues:
+    types: [ closed ]
+  workflow_run:
+    workflows: [ Check if PR has requird labels ]
+    types: [ completed ]
+
+jobs:
+  create-update-draft:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Create or update a release draft
+        uses: release-drafter/release-drafter@v6.0.0
+        with:
+          config-name: release-template.yml
+          disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # publish-release:
+  #   runs-on: ubuntu-latest
+  #   if: contains(github.event.issue.labels.*.name, 'release')
+  #   steps:
+  #     - name: Get latest releast draft
+  #       id: latest_draft
+  #       uses: pozetroninc/github-action-get-latest-release@master
+  #       with:
+  #         repository: mc2-center/data-models
+  #         token: ${{ secrets.GITHUB_TOKEN }}
+  
+  #     - name: Publish release draft
+  #       uses: eregon/publish-release@v1.0.6
+  #       with:
+  #         release_id: ${{ steps.latest_draft.outputs.id }}
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,8 +1,6 @@
-name: Create a new data model release
+name: Draft a new data model release
 
 on:
-  issues:
-    types: [ closed ]
   workflow_run:
     workflows: [ Check if PR has requird labels ]
     types: [ completed ]
@@ -22,21 +20,4 @@ jobs:
           disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # publish-release:
-  #   runs-on: ubuntu-latest
-  #   if: contains(github.event.issue.labels.*.name, 'release')
-  #   steps:
-  #     - name: Get latest releast draft
-  #       id: latest_draft
-  #       uses: pozetroninc/github-action-get-latest-release@master
-  #       with:
-  #         repository: mc2-center/data-models
-  #         token: ${{ secrets.GITHUB_TOKEN }}
   
-  #     - name: Publish release draft
-  #       uses: eregon/publish-release@v1.0.6
-  #       with:
-  #         release_id: ${{ steps.latest_draft.outputs.id }}
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #75 

## Changelog
* Add workflow to create (and update) a release draft; version number (`x.y.z`) will be determined based on the PR(s) included in the next planned release, where:
   * any PR labeled with `major` will increment `x`
   * any PR labeled with `minor` will increment `y`
   * any PR labeled with `patch` will increment `z`

    Note that only _one_ number will increment, where `x` will take precedence, followed by `y`, then finally `z`. For any PRs that are not related to the data model (like this PR) should be labeled with `non-release`.

   The draft content will follow this template:

   ```
     ## What's Changed

     $CHANGES

     ## Contributors

     $CONTRIBUTORS
   ```

* ~~(WIP) Add workflow step to publish the release draft when the `[release]` issue is closed~~ Not needed; release should manually be created