### PR TITLE
[docs]: Update landing page of the docs site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 Please read the [Contributing guidelines] on the Data Models Explorer
-docs site.
+docs site to learn more about how to contribute to the data models.
 
 [Contributing guidelines]: https://mc2-center.github.io/data-models/contributing/

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,6 @@
 Thank you for contributing to the MC2 Center data models project! This page
-will guide you through our development workflow and data model releases, as
-well as how to update this docs site.
+will guide you through our development workflow, data model release process, 
+and how to update this docs site.
 
 ### Development process
 
@@ -92,6 +92,11 @@ The Data Models Explorer uses [MkDocs], [mkdocs-table-reader-plugin], and the
     pip install mkdocs mkdocs-material mkdocs-table-reader-plugin pandas
     ```
 
+### I want to contribute something else...
+
+If there is something you'd like to contribute that was not covered on this page,
+please reach out to us on the [Discussions board]!
+
 [data-models repo]: https://github.com/mc2-center/data-models
 [Semantic Versioning]: https://semver.org/
 [Releases]: https://github.com/mc2-center/data-models/releases
@@ -99,3 +104,4 @@ The Data Models Explorer uses [MkDocs], [mkdocs-table-reader-plugin], and the
 [mkdocs-table-reader-plugin]: https://timvink.github.io/mkdocs-table-reader-plugin/
 [Material theme]: https://squidfunk.github.io/mkdocs-material/
 [pandas]: https://pandas.pydata.org/docs/index.html
+[Discussion board]: https://github.com/mc2-center/data-models/discussions

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -104,4 +104,4 @@ please reach out to us on the [Discussions board]!
 [mkdocs-table-reader-plugin]: https://timvink.github.io/mkdocs-table-reader-plugin/
 [Material theme]: https://squidfunk.github.io/mkdocs-material/
 [pandas]: https://pandas.pydata.org/docs/index.html
-[Discussion board]: https://github.com/mc2-center/data-models/discussions
+[Discussions board]: https://github.com/mc2-center/data-models/discussions

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ project by key, value, or descriptions.
 ### Next Steps
 
 To start contributing to your resources on the Cancer Complexity Knowledge
-Portal (CCKP), please read [our guidelines on how to contribute].
+Portal (CCKP), please read [our CCKP docs].
 
 ---
 
@@ -31,9 +31,13 @@ Portal (CCKP), please read [our guidelines on how to contribute].
 We are always looking for ways to improve our data models.  If there is
 an issue with an existing term - or if you have a suggestion - [let us know]!
 
-Please note that changing existing terminology may result in breaking
-changes downstream, so not all suggestions will be considered unless
-they are well-justified.
+Or, if you would like to contribute to the project directly, read our
+[contribution guidelines].
 
-[our guidelines on how to contribute] https://help.cancercomplexity.synapse.org/doc/contributing-and-updating-data-in-the-portal
+!!!important
+    Changing existing terminology may result in breaking changes downstream,
+    so not all suggestions may be considered unless they are well-justified.
+
+[our CCKP docs]: https://help.cancercomplexity.synapse.org/doc/contributing-and-updating-data-in-the-portal
+[contribution guidelines]: https://mc2-center.github.io/data-models/contributing/
 [let us know]: https://github.com/mc2-center/data-models/issues/new?assignees=aditigopalan&labels=bug&projects=&template=bug-report.md&title=%5Bbug%5D+

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,11 +19,21 @@ project by key, value, or descriptions.
 
 ---
 
+### Next Steps
+
+To start contributing to your resources on the Cancer Complexity Knowledge
+Portal (CCKP), please read [our guidelines on how to contribute].
+
+---
+
 ### Found an error?
 
 We are always looking for ways to improve our data models.  If there is
-an issue with an existing term - or if you have a suggestion - [let us know](https://github.com/mc2-center/data-models/issues/new?assignees=aditigopalan&labels=bug&projects=&template=bug-report.md&title=%5Bbug%5D+)!
+an issue with an existing term - or if you have a suggestion - [let us know]!
 
 Please note that changing existing terminology may result in breaking
 changes downstream, so not all suggestions will be considered unless
 they are well-justified.
+
+[our guidelines on how to contribute] https://help.cancercomplexity.synapse.org/doc/contributing-and-updating-data-in-the-portal
+[let us know]: https://github.com/mc2-center/data-models/issues/new?assignees=aditigopalan&labels=bug&projects=&template=bug-report.md&title=%5Bbug%5D+

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -1,3 +1,0 @@
-Use the Data Curator App (DCA) to add new resources to the CCKP.
-
-!!!note "More information coming soon"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,7 @@ nav:
       - Publication: valid_values/publication.md
       - Tool: valid_values/tool.md
   - Next Steps: next-steps.md
-  - Contributing: contributing.md
+  - Contributing to the Data Model: contributing.md
 
 # Theme configuration
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,7 +27,6 @@ nav:
       - Person: valid_values/person.md
       - Publication: valid_values/publication.md
       - Tool: valid_values/tool.md
-  - Next Steps: next-steps.md
   - Contributing to the Data Model: contributing.md
 
 # Theme configuration

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,9 +9,8 @@ repo_name: data-models
 
 # Navigation
 nav:
-  - Home: 
-    - index.md
-    - MC2 Center Data Models:
+  - Home: index.md
+  - Data Models:
       - Dataset Data Model: model/dataset.md
       - Education Resource Data Model: model/education.md
       - Grant Data Model: model/grant.md


### PR DESCRIPTION
Fixes #92 

## Changelog
<!-- Itemize the changes made in this PR, for example: -->
- Update tab title from "Contributing" to "Contributing to the Data Models"
 - Remove "Next Steps" tab
 - Add "Next Steps" section to the landing page, linking users out to the [CCKP docs](https://help.cancercomplexity.synapse.org/doc/contributing-and-updating-data-in-the-portal)
 - Create new tab called "Data Models" and move model docs over
 
## Preview

![Screenshot 2024-04-26 at 11 49 09 AM](https://github.com/mc2-center/data-models/assets/9377970/48153871-9644-4af0-bf20-bff0ddcd3ff7)
