### PR TITLE
Update file.md

### DIFF
--- a/docs/valid_values/file.md
+++ b/docs/valid_values/file.md
@@ -1,4 +1,4 @@
-List of standard terms for the [Dataset Sharing Plan Model](../model/file.md).
+List of standard terms for the [File Data Model](../model/file.md).
 
 ## Attribute: `File Level`
 


### PR DESCRIPTION
Change 'Dataset Sharing Plan' to 'File Data' on standard terms page for File Data Model

Fixes #125 

## Changelog
<!-- Itemize the changes made in this PR, for example: -->
 - Change 'Dataset Sharing Plan' to 'File Data' on standard terms page for File Data Model
 